### PR TITLE
number syntax update

### DIFF
--- a/ElixirLS.novaextension/Syntaxes/Elixir.xml
+++ b/ElixirLS.novaextension/Syntaxes/Elixir.xml
@@ -305,11 +305,20 @@
             <scope name="elixir.value.symbol">
                 <expression>:[A-Za-z][A-Za-zÀ-ÖØ-öø-ÿ0-9_]*</expression>
             </scope>
-            <scope name="elixir.value.number.hex">
-                <expression>\b0x[a-fA-F0-9]+\b</expression>
+            <scope name="elixir.value.number.binary">
+                <expression>\b[-+]?0b[01](?:[01]|[_01])*\b</expression>
             </scope>
-            <scope name="elixir.value.number">
-                <expression>\b\-?(?:\d+(?:\.\d*)?|(?:\.\d+))\b</expression>
+            <scope name="elixir.value.number.octal">
+                <expression>\b[-+]?0o[0-7](?:[0-7]|[_0-7])*\b</expression>
+            </scope>
+            <scope name="elixir.value.number.hex">
+                <expression>\b[-+]?0x[0-9a-fA-F](?:[0-9a-fA-F]|_[0-9a-fA-F])*\b</expression>
+            </scope>
+            <scope name="elixir.value.number.float">
+                <expression>\b[-+]?\d(?:\d|_\d)*\.\d(?:\d|_\d)*(?:[eE][-+]?\d(?:\d|_\d)*)?\b</expression>
+            </scope>
+            <scope name="elixir.value.number.decimal">
+                <expression>\b[-+]?\d(?:\d|_\d)*\b</expression>
             </scope>
         </collection>
         

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ cd elixir-ls
 mix deps.get
 mix compile
 mix elixir_ls.release -o ../ElixirLS.novaextension/elixir-ls-release
-cd ...
+cd ..
 
 # bundle nova extension
 yarn build # npm run build
 ```
 
-Finally, you have to activate this extension. To do this, click on 'Activate Project as Extension' in the menu 'Extensions'.
+Finally, you have to activate this extension. To do this, in Preferences -> General -> activate 'Show extension development items in the Extensions menu', and then click on 'Activate Project as Extension' in the menu 'Extensions'.
 
 ## Acknowledgements
 

--- a/src/ElixirLanguageServer.ts
+++ b/src/ElixirLanguageServer.ts
@@ -1,6 +1,6 @@
 import { findReferences } from "./commands/findReferences";
 import handleAddTextEditor from "./handlers/handleAddTextEditor";
-import { sendDidCangeConfigurationNotification } from "./notifications/didChangeConfiguration";
+import { sendDidChangeConfigurationNotification } from "./notifications/didChangeConfiguration";
 import { makeServerExecutable } from "./novaUtils";
 
 export default class ElixirLanguageServer {
@@ -41,7 +41,7 @@ export default class ElixirLanguageServer {
       nova.subscriptions.add(client);
       this.languageClient = client;
 
-      sendDidCangeConfigurationNotification(client, nova.config);
+      sendDidChangeConfigurationNotification(client, nova.config);
 
       // Find References
       nova.commands.register(

--- a/src/notifications/didChangeConfiguration.ts
+++ b/src/notifications/didChangeConfiguration.ts
@@ -1,4 +1,4 @@
-export function sendDidCangeConfigurationNotification(client, novaConfig) {
+export function sendDidChangeConfigurationNotification(client, novaConfig) {
   client.sendNotification("workspace/didChangeConfiguration", {
     settings: {
       elixirLS: {


### PR DESCRIPTION
was trying out this extension (thank you much for this extension!) and noticed that mix format enforces underscores that the highlighter didn't know about

![Screen Shot 2021-04-10 at 10 39 19 PM](https://user-images.githubusercontent.com/1629311/118403227-7cea7d00-b63b-11eb-8466-b9919bfeb38e.png)

this PR is probably not comprehensive, but i skimmed through https://github.com/elixir-lang/elixir/blob/master/lib/elixir/src/elixir_tokenizer.erl and I think this is closer to the compiler's understanding of numbers.  underscores are apparently acceptable throughout the number, and there are more number types than i knew.