### PR TITLE
adding the option to change projectDir in elixirLs

### DIFF
--- a/ElixirLS.novaextension/extension.json
+++ b/ElixirLS.novaextension/extension.json
@@ -43,6 +43,12 @@
       "description": "Automatically format a file on save",
       "type": "boolean",
       "default": false
+    },
+    {
+      "key": "elixir-ls.projectDir",
+      "title": "Project Directory",
+      "description": "Add configuration option for when your Mix project is in a subdirectory instead of the workspace root.",
+      "type": "string",
     }
   ],
 

--- a/ElixirLS.novaextension/extension.json
+++ b/ElixirLS.novaextension/extension.json
@@ -48,7 +48,7 @@
       "key": "elixir-ls.projectDir",
       "title": "Project Directory",
       "description": "Add configuration option for when your Mix project is in a subdirectory instead of the workspace root.",
-      "type": "string",
+      "type": "string"
     }
   ],
 

--- a/ElixirLS.novaextension/extension.json
+++ b/ElixirLS.novaextension/extension.json
@@ -48,7 +48,8 @@
       "key": "elixir-ls.projectDir",
       "title": "Project Directory",
       "description": "Add configuration option for when your Mix project is in a subdirectory instead of the workspace root.",
-      "type": "string"
+      "type": "string",
+      "default": "./"
     }
   ],
 

--- a/src/ElixirLanguageServer.ts
+++ b/src/ElixirLanguageServer.ts
@@ -25,7 +25,7 @@ export default class ElixirLanguageServer {
   start(path: string) {
     if (this.languageClient) {
       this.languageClient.stop();
-      nova.subscriptions.remove(this.languageClient as unknown as Disposable);
+      nova.subscriptions.remove(this.languageClient);
     }
 
     makeServerExecutable();
@@ -38,7 +38,7 @@ export default class ElixirLanguageServer {
       client.start();
 
       // Add the client to the subscriptions to be cleaned up
-      nova.subscriptions.add(client as unknown as Disposable);
+      nova.subscriptions.add(client);
       this.languageClient = client;
 
       sendDidChangeConfigurationNotification(client, nova.config);
@@ -56,7 +56,7 @@ export default class ElixirLanguageServer {
         handleAddTextEditor(
           this.mainDisposable,
           client,
-          nova.config.get("elixir-ls.formatOnSave") === 'true'
+          Boolean(nova.config.get("elixir-ls.formatOnSave"))
         )
       );
     } catch (err) {
@@ -90,7 +90,7 @@ export default class ElixirLanguageServer {
   stop() {
     if (this.languageClient) {
       this.languageClient.stop();
-      nova.subscriptions.remove(this.languageClient as unknown as Disposable);
+      nova.subscriptions.remove(this.languageClient);
       this.mainDisposable.dispose();
       this.languageClient = null;
     }

--- a/src/ElixirLanguageServer.ts
+++ b/src/ElixirLanguageServer.ts
@@ -25,7 +25,7 @@ export default class ElixirLanguageServer {
   start(path: string) {
     if (this.languageClient) {
       this.languageClient.stop();
-      nova.subscriptions.remove(this.languageClient);
+      nova.subscriptions.remove(this.languageClient as unknown as Disposable);
     }
 
     makeServerExecutable();
@@ -38,7 +38,7 @@ export default class ElixirLanguageServer {
       client.start();
 
       // Add the client to the subscriptions to be cleaned up
-      nova.subscriptions.add(client);
+      nova.subscriptions.add(client as unknown as Disposable);
       this.languageClient = client;
 
       sendDidChangeConfigurationNotification(client, nova.config);
@@ -90,7 +90,7 @@ export default class ElixirLanguageServer {
   stop() {
     if (this.languageClient) {
       this.languageClient.stop();
-      nova.subscriptions.remove(this.languageClient);
+      nova.subscriptions.remove(this.languageClient as unknown as Disposable);
       this.mainDisposable.dispose();
       this.languageClient = null;
     }

--- a/src/notifications/didChangeConfiguration.ts
+++ b/src/notifications/didChangeConfiguration.ts
@@ -1,4 +1,26 @@
+interface ElixirLS {
+  dialyzerEnabled: boolean;
+  dialyzerFormat: string;
+  mixEnv: string;
+  projectDir?: string;
+}
+
 export function sendDidChangeConfigurationNotification(client: LanguageClient, novaConfig: Configuration) {
+  let elixirLS: ElixirLS = {
+    dialyzerEnabled: Boolean(novaConfig.get("elixir-ls.dialyzerEnabled")),
+    dialyzerFormat: "dialyzer",
+    mixEnv: String(novaConfig.get("elixir-ls.mixEnv")),
+  }
+  
+  const projectDir = novaConfig.get("elixir-ls.projectDir");
+  
+  if (projectDir) {
+    elixirLS = {
+      ...elixirLS,
+      projectDir: String(projectDir)
+    }
+  }
+  
   client.sendNotification("workspace/didChangeConfiguration", {
     settings: {
       elixirLS: {

--- a/src/notifications/didChangeConfiguration.ts
+++ b/src/notifications/didChangeConfiguration.ts
@@ -1,29 +1,24 @@
 interface ElixirLS {
-  dialyzerEnabled: boolean;
-  dialyzerFormat: string;
-  mixEnv: string;
-  projectDir?: string;
+  dialyzerEnabled: boolean
+  dialyzerFormat: string
+  mixEnv: string
+  projectDir?: string
 }
 
-export function sendDidChangeConfigurationNotification(client: LanguageClient, novaConfig: Configuration) {
-  let elixirLS: ElixirLS = {
+export function sendDidChangeConfigurationNotification(
+  client: LanguageClient,
+  novaConfig: Configuration
+) {
+  const elixirLS: ElixirLS = {
     dialyzerEnabled: Boolean(novaConfig.get("elixir-ls.dialyzerEnabled")),
     dialyzerFormat: "dialyzer",
     mixEnv: String(novaConfig.get("elixir-ls.mixEnv")),
+    projectDir: String(novaConfig.get("elixir-ls.projectDir")),
   }
-  
-  const projectDir = novaConfig.get("elixir-ls.projectDir");
-  
-  if (projectDir) {
-    elixirLS = {
-      ...elixirLS,
-      projectDir: String(projectDir)
-    }
-  }
-  
+
   client.sendNotification("workspace/didChangeConfiguration", {
     settings: {
       elixirLS,
-    }
-  });
+    },
+  })
 }

--- a/src/notifications/didChangeConfiguration.ts
+++ b/src/notifications/didChangeConfiguration.ts
@@ -1,10 +1,11 @@
-export function sendDidChangeConfigurationNotification(client, novaConfig) {
+export function sendDidChangeConfigurationNotification(client: LanguageClient, novaConfig: Configuration) {
   client.sendNotification("workspace/didChangeConfiguration", {
     settings: {
       elixirLS: {
         dialyzerEnabled: novaConfig.get("elixir-ls.dialyzerEnabled"),
         dialyzerFormat: "dialyzer",
         mixEnv: novaConfig.get("elixir-ls.mixEnv"),
+        projectDir: novaConfig.get("elixir-ls.projectDir") || null
       },
     },
   });

--- a/src/notifications/didChangeConfiguration.ts
+++ b/src/notifications/didChangeConfiguration.ts
@@ -23,12 +23,7 @@ export function sendDidChangeConfigurationNotification(client: LanguageClient, n
   
   client.sendNotification("workspace/didChangeConfiguration", {
     settings: {
-      elixirLS: {
-        dialyzerEnabled: novaConfig.get("elixir-ls.dialyzerEnabled"),
-        dialyzerFormat: "dialyzer",
-        mixEnv: novaConfig.get("elixir-ls.mixEnv"),
-        projectDir: novaConfig.get("elixir-ls.projectDir") || null
-      },
-    },
+      elixirLS,
+    }
   });
 }


### PR DESCRIPTION
Hello, thank you very much for your extension, i just figured, this setting that i need from `elixirLS` is missing and decided to add it, already tested it on my editor and it works, i would like to know your opinion as you probably have much more experience dealing with both LSP and Nova API than 

i work in a mono repo with an umbrella app, my mix file is in a different directory than where I open the workspace in my editor, because of the current state and configuration, it causes me to get constantly the following error https://github.com/elixir-lsp/elixir-ls/blob/423d7f8d8d173c8ec362f50f09449be6592cc972/apps/language_server/lib/language_server/server.ex#L956 or 

```
 "No mixfile found in project.  To use a subdirectory, set `elixirLS.projectDir` in your settings"
```