### PR TITLE
Show modules and functions in the "Symbols" sidebar

### DIFF
--- a/ElixirLS.novaextension/Queries/symbols.scm
+++ b/ElixirLS.novaextension/Queries/symbols.scm
@@ -4,7 +4,7 @@
 (call
   target: (identifier) @ignore
   (arguments (alias) @name)
-  (#match? @ignore "^(defmodule|defprotocol)$")) @definition.module
+  (#match? @ignore "^(defmodule|defprotocol)$") (#set! role class)) @subtree
 
 ; * functions/macros
 (call
@@ -20,7 +20,8 @@
         left: (call target: (identifier) @name)
         operator: "when")
     ])
-  (#match? @ignore "^(def|defp|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp)$")) @definition.function
+  (#match? @ignore "^(def|defp|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp)$")
+  (#set! role function)) @subtree
 
 ; References
 

--- a/ElixirLS.novaextension/Syntaxes/Elixir.xml
+++ b/ElixirLS.novaextension/Syntaxes/Elixir.xml
@@ -11,6 +11,7 @@
         <highlights />
         <folds />
         <injections />
+        <symbols />
     </tree-sitter>
 
     <detectors>


### PR DESCRIPTION
Partially fixes https://github.com/raulchedrese/nova-elixir-ls/issues/22

With this change, modules and functions show up in the "Symbols" sidebar, but unfortunately they still don't show up in "Open Quickly In Symbols" and I haven't figured out why yet. I think this is a definite improvement on its own though.