### PR TITLE
Add option to configure a custom language server

### DIFF
--- a/ElixirLS.novaextension/extension.json
+++ b/ElixirLS.novaextension/extension.json
@@ -49,7 +49,14 @@
       "description": "Add configuration option for when your Mix project is in a subdirectory instead of the workspace root.",
       "type": "string",
       "default": "./"
-    }
+    },
+    {
+      "key": "elixir-ls.language-server-path",
+      "title": "Language Server",
+      "description": "Path to a custom language server e.g. /home/user/.local/bin/elixir/language_server.sh. Leave empty to use the default.",
+      "type": "string",
+      "default": ""
+    },
   ],
 
   "sidebars": [

--- a/src/ElixirLanguageServer.ts
+++ b/src/ElixirLanguageServer.ts
@@ -70,9 +70,10 @@ export default class ElixirLanguageServer {
 
   createClient(path: string): LanguageClient {
     // Use the default server path
-    if (!path) {
+    if (!path || path === "") {
       path = nova.extension.path + "/elixir-ls-release/language_server.sh";
     }
+    console.info("Using language server at %s", path)
     const serverOptions = {
       path: path,
     };

--- a/src/ElixirLanguageServer.ts
+++ b/src/ElixirLanguageServer.ts
@@ -28,7 +28,10 @@ export default class ElixirLanguageServer {
       nova.subscriptions.remove(this.languageClient);
     }
 
-    makeServerExecutable(path);
+    if (!path || path === "") {
+      // using built-in language server
+      makeServerExecutable();
+    }
 
     const client = this.createClient(path);
 
@@ -73,7 +76,7 @@ export default class ElixirLanguageServer {
     if (!path || path === "") {
       path = nova.extension.path + "/elixir-ls-release/language_server.sh";
     }
-    console.info("Using language server at %s", path)
+    console.info("Using language server at %s", path);
     const serverOptions = {
       path: path,
     };

--- a/src/ElixirLanguageServer.ts
+++ b/src/ElixirLanguageServer.ts
@@ -28,7 +28,7 @@ export default class ElixirLanguageServer {
       nova.subscriptions.remove(this.languageClient);
     }
 
-    makeServerExecutable();
+    makeServerExecutable(path);
 
     const client = this.createClient(path);
 

--- a/src/notifications/didChangeConfiguration.ts
+++ b/src/notifications/didChangeConfiguration.ts
@@ -3,6 +3,7 @@ interface ElixirLS {
   dialyzerFormat: string
   mixEnv: string
   projectDir?: string
+  languageServerPath?: string
 }
 
 export function sendDidChangeConfigurationNotification(
@@ -14,6 +15,7 @@ export function sendDidChangeConfigurationNotification(
     dialyzerFormat: "dialyzer",
     mixEnv: String(novaConfig.get("elixir-ls.mixEnv")),
     projectDir: String(novaConfig.get("elixir-ls.projectDir")),
+    languageServerPath: String(novaConfig.get("elixir-ls.language-server-path"))
   }
 
   client.sendNotification("workspace/didChangeConfiguration", {

--- a/src/novaUtils.ts
+++ b/src/novaUtils.ts
@@ -56,7 +56,7 @@ export function jumpToRange(
   });
 }
 
-export const makeServerExecutable = () => {
+export const makeServerExecutable = (path: string) => {
   if (!path || path === "") {
     // using a custom path, no permissions will be changed
     return

--- a/src/novaUtils.ts
+++ b/src/novaUtils.ts
@@ -57,6 +57,10 @@ export function jumpToRange(
 }
 
 export const makeServerExecutable = () => {
+  if (!path || path === "") {
+    // using a custom path, no permissions will be changed
+    return
+  }
   const serverProcess = new Process("/usr/bin/env", {
     args: [
       "chmod",

--- a/src/novaUtils.ts
+++ b/src/novaUtils.ts
@@ -56,11 +56,7 @@ export function jumpToRange(
   });
 }
 
-export const makeServerExecutable = (path: string) => {
-  if (!path || path === "") {
-    // using a custom path, no permissions will be changed
-    return
-  }
+export const makeServerExecutable = () => {
   const serverProcess = new Process("/usr/bin/env", {
     args: [
       "chmod",


### PR DESCRIPTION
This PR enables the extension to use a custom language server.

* Added configuration option “Language Server” expecting the path to the `language_server.sh` of a local build of https://github.com/elixir-lsp/elixir-ls.
* The extension will not attempt to change permissions when using a custom language server.